### PR TITLE
Arm64 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ RUN         mkdir -p /build /unpack
 WORKDIR     /unpack
 ADD         assets/repack.sh .
 ARG         FCREPO_VERSION
-RUN         ./repack.sh
+RUN         bash ./repack.sh
 
-FROM        jetty:jre8-alpine
+FROM        jetty:9-jre8
 USER        root
-RUN         apk update && apk add bash
 RUN         mkdir -p /data ${JETTY_BASE}/etc ${JETTY_BASE}/modules
 ADD         assets/fedora-entrypoint.sh /
 ADD         --chown=jetty:jetty assets/fedora.xml ${JETTY_BASE}/webapps/fedora.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG         FCREPO_VERSION
 RUN         bash ./repack.sh
 
 FROM        jetty:9-jre8
+LABEL       org.opencontainers.image.source https://github.com/samvera-labs/docker-fcrepo
 USER        root
 RUN         mkdir -p /data ${JETTY_BASE}/etc ${JETTY_BASE}/modules
 ADD         assets/fedora-entrypoint.sh /

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -11,13 +11,13 @@ To run a generic Fedora server with an ephemeral datastore and the same default,
 as the “one-click” test configuration:
 
 ```bash
-docker run -ti -p 8080:8080 samvera/fcrepo4:VERSION
+docker run -ti -p 8080:8080 ghcr.io/samvera/fcrepo4:VERSION
 ```
 
 e.g.:
 
 ```bash
-docker run -ti -p 8080:8080 samvera/fcrepo4:5.1.0
+docker run -ti -p 8080:8080 ghcr.io/samvera/fcrepo4:4.7.5
 ```
 
 ### Overriding Default Configuration
@@ -29,7 +29,7 @@ rebuilding the container. Simply mount the new configuration like so:
 ```bash
 docker run -ti -p 8080:8080 \
   -v /path/to/my/configs:/jetty-overrides \
-  samvera/fcrepo4:5.1.0
+  ghcr.io/samvera/fcrepo4:4.7.5
 ```
 
 For more information regarding Jetty configuration, see the

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ bin/build VERSION
 Example:
 
 ```bash
-bin/build 5.1.0 # Produces an image tagged samvera/fcrepo4:5.1.0
+bin/build 5.1.0 # Produces an image tagged ghcr.io/samvera/fcrepo4:5.1.0
 ```
 
 If you'd like to use something other than the default target repository
-(`samvera/fcrepo4`), set the `DOCKER_REPO` variable:
+(`ghcr.io/samvera/fcrepo4`), set the `DOCKER_REPO` variable:
 
 ```bash
 DOCKER_REPO=foo/bar bin/build 5.1.0 # Produces an image tagged foo/bar:5.1.0

--- a/assets/fedora-entrypoint.sh
+++ b/assets/fedora-entrypoint.sh
@@ -37,4 +37,4 @@ fi
 
 MODESHAPE_CONFIG=${MODESHAPE_CONFIG:-classpath:/config/${DEFAULT_CONFIG}/repository.json}
 export JAVA_OPTIONS="${JAVA_OPTIONS} -Dfcrepo.home=/data -Dfcrepo.modeshape.configuration=${MODESHAPE_CONFIG}"
-su -s /bin/ash -c "exec /docker-entrypoint.sh $@" jetty
+su -s /bin/bash -c "exec /docker-entrypoint.sh $@" jetty

--- a/assets/fedora-entrypoint.sh
+++ b/assets/fedora-entrypoint.sh
@@ -13,8 +13,7 @@ for MEM_FILE in memory.max memory/memory.limit_in_bytes memory/memory.memsw.limi
 done
 
 if [[ ! -e /sys/fs/cgroup/${MEM_FILE} ]]; then
-  echo "Could not read container memory. Exiting."
-  exit 1
+  echo "Could not read container memory."
 fi
 
 if [[ -d /jetty-overrides ]]; then
@@ -24,7 +23,7 @@ if [[ -d /jetty-overrides ]]; then
 fi
 
 MEM_BYTES=$(cat /sys/fs/cgroup/${MEM_FILE})
-if [[ $MEM_BYTES -ne "max" && $MEM_BYTES -ne "9223372036854771712" ]]; then
+if [[ -e /sys/fs/cgroup/${MEM_FILE} && $MEM_BYTES -ne "max" && $MEM_BYTES -ne "9223372036854771712" ]]; then
   let "MX=$MEM_BYTES * 8 / 10 / 1024 / 1024"
   echo "Setting -Xmx${MX}m"
   JAVA_OPTIONS="${JAVA_OPTIONS} -Xmx${MX}m"

--- a/assets/fedora-entrypoint.sh
+++ b/assets/fedora-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Changing ownership of /data as $(whoami)"
-chown jetty:jetty /data
+chown -R jetty:jetty /data
 echo "Downgrading privileges and resuming"
 
 for MEM_FILE in memory.max memory/memory.limit_in_bytes memory/memory.memsw.limit_in_bytes memory/memory.kmem.limit_in_bytes; do

--- a/bin/build
+++ b/bin/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_REPO=${DOCKER_REPO:-samvera/fcrepo4}
+DOCKER_REPO=${DOCKER_REPO:-ghcr.io/samvera/fcrepo4}
 
 function latest_release() {
   curl -s -H accept:application/vnd.github.v3+json https://api.github.com/repos/fcrepo4/fcrepo4/releases/latest | jq -r '.tag_name | split("-") | last'

--- a/bin/build
+++ b/bin/build
@@ -9,4 +9,5 @@ function latest_release() {
 FCREPO_VERSION=${1:-$(latest_release)}
 echo -n 'Building release: '
 echo $FCREPO_VERSION
-docker build --build-arg FCREPO_VERSION=$FCREPO_VERSION -t $DOCKER_REPO:$FCREPO_VERSION .
+docker buildx create --use
+docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg FCREPO_VERSION=$FCREPO_VERSION -t $DOCKER_REPO:$FCREPO_VERSION .

--- a/bin/build-all
+++ b/bin/build-all
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-DOCKER_REPO=${DOCKER_REPO:-samvera/fcrepo4}
+DOCKER_REPO=${DOCKER_REPO:-ghcr.io/samvera/fcrepo4}
 
 RELEASES=$(curl --silent -f -lSL 'https://api.github.com/repos/fcrepo4/fcrepo4/releases?per_page=50' \
             | jq -r '.[].tag_name' \
             | cut -d '-' -f 2-)
 TO_BUILD=""
+docker buildx create --use
 for v in $RELEASES; do
   clear
   echo "Building release ${v}"
-  docker build --build-arg FCREPO_VERSION=$v -t $DOCKER_REPO:$v .
+  docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg FCREPO_VERSION=$v -t $DOCKER_REPO:$v .
 done


### PR DESCRIPTION
M1 Macs (with arm64 cpus) are not able to use the fcrepo image based on the jetty:jre8-alpine image. This updates the build to use a more recent jetty image, however jetty dropped alpine images some time ago.