### PR TITLE
Pull newer versions of JDBC connectors for fcrepo4 4.x versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ RUN         mkdir -p /build /unpack
 WORKDIR     /unpack
 ADD         assets/repack.sh .
 ARG         FCREPO_VERSION
+ARG         MYSQL_CONNECTOR_VERSION=8.0.30
+ARG         PSQL_CONNECTOR_VERSION=42.4.1
 RUN         bash ./repack.sh
 
 FROM        jetty:9-jre8

--- a/assets/repack.sh
+++ b/assets/repack.sh
@@ -12,7 +12,19 @@ curl --silent -I https://raw.githubusercontent.com/fcrepo4/fcrepo4/fcrepo-${FCRE
 if [[ $? == 0 ]]; then
   echo "Downloading Fedora v${FCREPO_VERSION} one-click web.xml"
   curl -# -Lo WEB-INF/web.xml https://raw.githubusercontent.com/fcrepo4/fcrepo4/fcrepo-${FCREPO_VERSION}/fcrepo-webapp/src/main/jetty-console/WEB-INF/web.xml
-  echo "Repacking Fedora v${FCREPO_VERSION} .war file"
-  jar -cf /build/fedora.war .
 fi
+
+if [[ ${FCREPO_VERSION} =~ ^4\..*$ ]]; then
+  echo "Updating MySql JDBC connector to ${MYSQL_CONNECTOR_VERSION}"
+  rm -v WEB-INF/lib/mysql-connector-java*.jar
+  curl -# -Lo WEB-INF/lib/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar
+
+  echo "Updating Postgresql JDBC connector to ${PSQL_CONNECTOR_VERSION}"
+  rm -v WEB-INF/lib/postgresql*.jar
+ curl -# -Lo WEB-INF/lib/postgresql-${PSQL_CONNECTOR_VERSION}.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/${PSQL_CONNECTOR_VERSION}/postgresql-${PSQL_CONNECTOR_VERSION}.jar
+fi
+
+echo "Repacking Fedora v${FCREPO_VERSION} .war file"
+jar -cf /build/fedora.war .
+
 cp WEB-INF/web.xml /build/override-web.xml

--- a/bin/build
+++ b/bin/build
@@ -3,7 +3,7 @@
 DOCKER_REPO=${DOCKER_REPO:-ghcr.io/samvera/fcrepo4}
 
 function latest_release() {
-  curl -s -H accept:application/vnd.github.v3+json https://api.github.com/repos/fcrepo4/fcrepo4/releases/latest | jq -r '.tag_name | split("-") | last'
+  curl -s -H accept:application/vnd.github.v3+json https://api.github.com/repositories/7992797/releases/latest | jq -r '.tag_name | split("-") | last'
 }
 
 FCREPO_VERSION=${1:-$(latest_release)}

--- a/bin/build-all
+++ b/bin/build-all
@@ -2,7 +2,7 @@
 
 DOCKER_REPO=${DOCKER_REPO:-ghcr.io/samvera/fcrepo4}
 
-RELEASES=$(curl --silent -f -lSL 'https://api.github.com/repos/fcrepo4/fcrepo4/releases?per_page=50' \
+RELEASES=$(curl --silent -f -lSL 'https://api.github.com/repositories/7992797/releases?per_page=50' \
             | jq -r '.[].tag_name' \
             | cut -d '-' -f 2-)
 TO_BUILD=""


### PR DESCRIPTION
The last version of fcrepo 4.x is 4.7.5 which includes mysql-jdbc-connector-5.1.38.jar and postgres-8.4.1211.jar.  I had problems using this old of a mysql connector to connect to a mysql 8 database.  Swapping out the connector worked perfectly.  I also had success locally doing the same with the postgres connector to connect to a local postgres 14 database.  These changes would allow newer images to be built to help carry fcrepo4 forward while there aren't any newer official releases.

I also had to update the github api url in order for the build script to work for me.